### PR TITLE
Fix baguette.js

### DIFF
--- a/commands/fun/baguette.js
+++ b/commands/fun/baguette.js
@@ -1,4 +1,4 @@
-class Choose {
+class Baguette {
     constructor() {
         this.help = {
             name: 'baguette',


### PR DESCRIPTION
Rename the class to Baguette as its exported as Baguette, would therefore fail since the Baguette class wasn't existing